### PR TITLE
Corrected application.yaml in archetype

### DIFF
--- a/mangooio-maven-archetype/src/main/resources/archetype-resources/src/main/resources/application.yaml
+++ b/mangooio-maven-archetype/src/main/resources/archetype-resources/src/main/resources/application.yaml
@@ -21,12 +21,12 @@ default:
             cssfolder : /bar
             gzipjs    : false
             gzipcss   : false
-        auth:
-            redirect  : /login
-            cookie:
-                name    : ${application-name}-AUTH
-                encrypt : false
-                expires : 86400
+    auth:
+        redirect  : /login
+        cookie:
+            name    : ${application-name}-AUTH
+            encrypt : false
+            expires : 86400
     cookie:
         name       : ${application-name}-SESSION
         expires    : 86400


### PR DESCRIPTION
The archetype file application.yaml is not consistent with the actual names in the [Key](https://github.com/svenkubiak/mangooio/blob/master/mangooio-core/src/main/java/io/mangoo/enums/Key.java) enum regarding authentication.