### PR TITLE
fix #222 : add default listen on 8000 for  jpda connection

### DIFF
--- a/mangooio-maven-plugin/src/main/java/io/mangoo/build/Runner.java
+++ b/mangooio-maven-plugin/src/main/java/io/mangoo/build/Runner.java
@@ -48,13 +48,15 @@ public class Runner {
     private final String mainClass;
     private final String classpath;
     private final File mavenBaseDir;
+    private final int jpdaPort;
 
-    public Runner(String mainClass, String classpath, File mavenBaseDir) {
+    public Runner(String mainClass, String classpath, File mavenBaseDir, int jpdaPort) {
         this.outputStream = System.out; //NOSONAR
         this.mainClass = mainClass;
         this.classpath = classpath;
         this.mavenBaseDir = mavenBaseDir;
         this.restarting = new AtomicBoolean(false);
+        this.jpdaPort = jpdaPort;
     }
 
     public OutputStream getOutput() {
@@ -107,6 +109,12 @@ public class Runner {
         String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
 
         commandLine.add(javaBin);
+        if (jpdaPort > 0) {
+            LOG.warn("Listening for jpda Connection at "+jpdaPort);
+            //-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8090
+            commandLine.add("-Xdebug");
+            commandLine.add(String.format("-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=%s", jpdaPort));
+        }
         commandLine.add("-Dapplication.mode=dev");
         commandLine.add("-cp");
         commandLine.add(classpath);

--- a/mangooio-maven-plugin/src/main/java/io/mangoo/maven/MangooMojo.java
+++ b/mangooio-maven-plugin/src/main/java/io/mangoo/maven/MangooMojo.java
@@ -73,6 +73,9 @@ public class MangooMojo extends AbstractMojo {
     @Parameter(property = "mangoo.skip", defaultValue="false", required = true)
     private boolean skip;
 
+    @Parameter(property = "mangoo.jpdaPort", defaultValue="8000", required = true)
+    private int jpdaPort;
+
     @Parameter(property = "mangoo.outputDirectory", defaultValue = "${project.build.outputDirectory}", required = true)
     private String buildOutputDirectory;
 
@@ -136,7 +139,7 @@ public class MangooMojo extends AbstractMojo {
 
     private void startRunner(List<String> classpathItems, Set<String> includesSet, Set<String> excludesSet, Set<Path> watchDirectories) {
         try {
-            Runner machine = new Runner(Application.class.getName(), StringUtils.join(classpathItems, File.pathSeparator), project.getBasedir());
+            Runner machine = new Runner(Application.class.getName(), StringUtils.join(classpathItems, File.pathSeparator), project.getBasedir(), jpdaPort);
 
             Trigger restartTrigger = new Trigger(machine);
             restartTrigger.setSettleDownMillis(settleDownMillis);


### PR DESCRIPTION
the application in devmode will open a jpda connection on port 8000 , a remoter debugging session can be created from IDE to enable step-by-step debugging

The User can also configure the Debug Port by setting jpdaPort in configuration section of mangooio plugin

```
<plugin>
                <groupId>io.mangoo</groupId>
                <artifactId>mangooio-maven-plugin</artifactId>
                <version>${mangooio.version}</version>
                <configuration>
                    <jpdaPort>8090</jpdaPort>
                </configuration>
  </plugin>
```