### PR TITLE
Add Jvm Args supplied by the User to the Application

### DIFF
--- a/mangooio-maven-plugin/src/main/java/io/mangoo/build/Runner.java
+++ b/mangooio-maven-plugin/src/main/java/io/mangoo/build/Runner.java
@@ -20,10 +20,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.advantageous.boon.core.Str;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.zeroturnaround.exec.ProcessExecutor;
@@ -49,14 +52,16 @@ public class Runner {
     private final String classpath;
     private final File mavenBaseDir;
     private final int jpdaPort;
+    private final String jvmArgs;
 
-    public Runner(String mainClass, String classpath, File mavenBaseDir, int jpdaPort) {
+    public Runner(String mainClass, String classpath, File mavenBaseDir, int jpdaPort, String jvmArgs) {
         this.outputStream = System.out; //NOSONAR
         this.mainClass = mainClass;
         this.classpath = classpath;
         this.mavenBaseDir = mavenBaseDir;
         this.restarting = new AtomicBoolean(false);
         this.jpdaPort = jpdaPort;
+        this.jvmArgs = jvmArgs;
     }
 
     public OutputStream getOutput() {
@@ -113,6 +118,11 @@ public class Runner {
             LOG.info("Listening for jpda connection at " + jpdaPort);
             commandLine.add("-Xdebug");
             commandLine.add(String.format("-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=%s", jpdaPort));
+        }
+        if(StringUtils.isNotEmpty(jvmArgs)){
+            Arrays.stream(jvmArgs.split(" "))
+                    .filter(arg->arg.length()>0)
+                    .forEach(arg->commandLine.add(arg));
         }
         commandLine.add("-Dapplication.mode=dev");
         commandLine.add("-cp");

--- a/mangooio-maven-plugin/src/main/java/io/mangoo/maven/MangooMojo.java
+++ b/mangooio-maven-plugin/src/main/java/io/mangoo/maven/MangooMojo.java
@@ -76,6 +76,9 @@ public class MangooMojo extends AbstractMojo {
     @Parameter(property = "mangoo.jpdaPort", defaultValue="8000", required = true)
     private int jpdaPort;
 
+    @Parameter(property = "mangoo.jvmArgs", required = false)
+    private String jvmArgs;
+
     @Parameter(property = "mangoo.outputDirectory", defaultValue = "${project.build.outputDirectory}", required = true)
     private String buildOutputDirectory;
 
@@ -139,7 +142,12 @@ public class MangooMojo extends AbstractMojo {
 
     private void startRunner(List<String> classpathItems, Set<String> includesSet, Set<String> excludesSet, Set<Path> watchDirectories) {
         try {
-            Runner machine = new Runner(Application.class.getName(), StringUtils.join(classpathItems, File.pathSeparator), project.getBasedir(), jpdaPort);
+            Runner machine = new Runner(
+                    Application.class.getName(),
+                    StringUtils.join(classpathItems, File.pathSeparator),
+                    project.getBasedir(),
+                    jpdaPort,
+                    jvmArgs);
 
             Trigger restartTrigger = new Trigger(machine);
             restartTrigger.setSettleDownMillis(settleDownMillis);


### PR DESCRIPTION
in dev mode when using Ebean it's far easier to enhance the beans using an agent rather than a maven plugin

`

       <plugin>
                <groupId>io.mangoo</groupId>

                <artifactId>mangooio-maven-plugin</artifactId>

                <version>${mangooio.version}</version>

                <configuration>

                    <jvmArgs>-javaagent:ebean-agent-8.1.1.jar</jvmArgs

                </configuration>

            </plugin>

`

this pull request will take the jvmArgs and add it to the commandLine (it'll split by space and remove empty space args)