### PR TITLE
Get Declared Method to support inheritence

### DIFF
--- a/mangooio-core/src/main/java/io/mangoo/routing/handlers/DispatcherHandler.java
+++ b/mangooio-core/src/main/java/io/mangoo/routing/handlers/DispatcherHandler.java
@@ -82,7 +82,7 @@ public class DispatcherHandler implements HttpHandler {
         try {
             this.method = Application.getInstance(this.controllerClass)
                     .getClass()
-                    .getMethod(this.controllerMethodName, this.methodParameters.values().toArray(new Class[0]));
+                    .getDeclaredMethod(this.controllerMethodName, this.methodParameters.values().toArray(new Class[0]));
             
             for (Annotation annotation : this.method.getAnnotations()) {
                 if (annotation.annotationType().equals(FilterWith.class)) {


### PR DESCRIPTION
.getMethod does not return inherited methods, preventing the usage of inheritance in controllers.

Currently can be bypassed by implementing the method in both and calling super, but not exactly convenient.

Perhaps there is a reason, but this seems like a good idea to me.