### PR TITLE
Root path when creating changed session cookie

### DIFF
--- a/mangooio-core/src/main/java/io/mangoo/routing/handlers/OutboundCookiesHandler.java
+++ b/mangooio-core/src/main/java/io/mangoo/routing/handlers/OutboundCookiesHandler.java
@@ -102,7 +102,8 @@ public class OutboundCookiesHandler implements HttpHandler {
                         .setSameSite(true)
                         .setSameSiteMode(SAME_SITE_MODE)
                         .setHttpOnly(true)
-                        .setSecure(this.config.isSessionCookieSecure());
+                        .setSecure(this.config.isSessionCookieSecure())
+                        .setPath("/");
                 
                 if (session.getExpires() != null) {
                     cookie.setExpires(DateUtils.localDateTimeToDate(session.getExpires()));


### PR DESCRIPTION
Currently, by default the web browser assumes that the path is the current URL - the result being that the session cookie becomes unusable.

Change tested locally.