### PR TITLE
Upgrade LessCSS Compiler to 2.0.0

### DIFF
--- a/mangooio-core/pom.xml
+++ b/mangooio-core/pom.xml
@@ -30,7 +30,7 @@
 		</dependency>
 		<dependency>
 			<groupId>biz.gabrys.lesscss</groupId>
-			<artifactId>compiler</artifactId>
+			<artifactId>lesscss-compiler2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jodd</groupId>

--- a/mangooio-core/src/main/java/io/mangoo/routing/handlers/AuthorizationHandler.java
+++ b/mangooio-core/src/main/java/io/mangoo/routing/handlers/AuthorizationHandler.java
@@ -2,9 +2,10 @@ package io.mangoo.routing.handlers;
 
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.google.inject.Inject;
 
-import biz.gabrys.lesscss.compiler.StringUtils;
 import io.mangoo.core.Application;
 import io.mangoo.core.Config;
 import io.mangoo.enums.Header;

--- a/mangooio-maven-plugin/src/main/java/io/mangoo/build/Minification.java
+++ b/mangooio-maven-plugin/src/main/java/io/mangoo/build/Minification.java
@@ -5,14 +5,14 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.Charset;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import biz.gabrys.lesscss.compiler.CompilerException;
-import biz.gabrys.lesscss.compiler.LessCompiler;
-import biz.gabrys.lesscss.compiler.LessCompilerImpl;
+import biz.gabrys.lesscss.compiler2.CompilerException;
+import biz.gabrys.lesscss.compiler2.LessCompiler;
 import io.bit3.jsass.CompilationException;
 import io.bit3.jsass.Compiler;
 import io.bit3.jsass.Options;
@@ -113,13 +113,12 @@ public final class Minification {
     }
 
     private static void lessify(File lessFile) {
-        LessCompiler compiler = new LessCompilerImpl();
+        final LessCompiler compiler = new LessCompiler();
         final File outputFile = getOutputFile(lessFile, Suffix.CSS);
         try {
-            String css = compiler.compile(lessFile);
-            FileUtils.writeStringToFile(outputFile, css, Default.ENCODING.toString());
+            compiler.compile(lessFile, outputFile, Charset.forName(Default.ENCODING.toString()));
             logPreprocess(lessFile, outputFile);
-        } catch (IOException | CompilerException e) {
+        } catch (final CompilerException e) {
             LOG.error("Failed to preprocess LESS file", e);
         }
     }

--- a/mangooio-test/src/main/java/io/mangoo/test/http/TestResponse.java
+++ b/mangooio-test/src/main/java/io/mangoo/test/http/TestResponse.java
@@ -22,12 +22,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.google.common.collect.Multimap;
 
-import biz.gabrys.lesscss.compiler.StringUtils;
 import io.mangoo.core.Application;
 import io.mangoo.core.Config;
 import io.mangoo.enums.Default;

--- a/pom.xml
+++ b/pom.xml
@@ -385,8 +385,8 @@
 			</dependency>
 			<dependency>
 				<groupId>biz.gabrys.lesscss</groupId>
-				<artifactId>compiler</artifactId>
-				<version>1.2.2</version>
+				<artifactId>lesscss-compiler2</artifactId>
+				<version>2.0.0</version>
 			</dependency>
 			<dependency>
 				<groupId>io.github.classgraph</groupId>


### PR DESCRIPTION
Changes:
- adjust code to the new LessCompiler 2.X API
- always use StringUtils from Apache Commons

Comments:
- LessCompiler 2.X supports files located on a local drive, but also provided by HTTP, HTTPS, FTP, `classpath://` and custom protocols (see [FileSystem](http://lesscss-compiler.projects.gabrys.biz/2.0.0/apidocs/index.html?biz/gabrys/lesscss/compiler2/filesystem/FileSystem.html)). 1.X loads files only from the local drive. I didn't change this behavior in your library. If you would like to change this - let me know. I can help you to enable additional protocols 🙂
- the library uses rhino 1.7.10 (the latest released version at this moment, see [dependencies](http://lesscss-compiler.projects.gabrys.biz/2.0.0/dependencies.html))
- I executed `mvn clean install` without `mangooio-integration-test` (some tests, unrelated  to my changes, were failing)
- I think you accidentally used `StringUtils` from LessCSS Compiler instead of Apache Commons. I switched to Apache Commons. Of course if you would like to use `StringUtils` from LessCSS Compiler, it is still available and contains more methods ([see JavaDoc](http://lesscss-compiler.projects.gabrys.biz/2.0.0/apidocs/index.html?biz/gabrys/lesscss/compiler2/util/StringUtils.html))

Cheers 👋 

