### PR TITLE
.4062073974432528:17cb29cbf70d8e7a2c573dabdd1719b3_69e9a15b7944aa7e5462126f.69e9a24f7944aa7e54621271.69e9a24e62e4396976893da0:Trae CN.T(2026/4/23 12:38:39)

### DIFF
--- a/mangooio-core/src/main/java/io/mangoo/constants/Default.java
+++ b/mangooio-core/src/main/java/io/mangoo/constants/Default.java
@@ -17,7 +17,7 @@ public final class Default {
     public static final long AUTHENTICATION_COOKIE_REMEMBER_EXPIRES = 2592000;
     public static final String AUTHENTICATION_COOKIE_SAME_SITE_MODE = "Strict";
     public static final Boolean AUTHENTICATION_COOKIE_SECURE = Boolean.FALSE;
-    public static final long AUTHENTICATION_COOKIE_TOKEN_EXPIRES = 3600;
+    public static final long AUTHENTICATION_COOKIE_TOKEN_EXPIRES = 86400;
     public static final int AUTHENTICATION_LOCK = 10;
     public static final Boolean AUTHENTICATION_ORIGIN = Boolean.FALSE;
     public static final String BUNDLE_NAME = "translations/messages";

--- a/mangooio-core/src/main/java/io/mangoo/utils/CommonUtils.java
+++ b/mangooio-core/src/main/java/io/mangoo/utils/CommonUtils.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.time.LocalDateTime;
 import java.util.*;
 
 public final class CommonUtils {
@@ -431,6 +432,11 @@ public final class CommonUtils {
                 .getInstance(CacheProvider.class)
                 .getCache(CacheName.BLACKLIST);
 
-        authCache.put(Const.BLACKLIST_PREFIX + id, Strings.EMPTY);
+        var config = Application.getInstance(Config.class);
+        authCache.put(
+                Const.BLACKLIST_PREFIX + id,
+                Strings.EMPTY,
+                LocalDateTime.now().plusSeconds(config.getAuthenticationCookieRememberExpires())
+        );
     }
 }


### PR DESCRIPTION
将认证令牌默认过期时间从3600秒增加到86400秒
为黑名单缓存添加过期时间，使用记住我cookie的过期时间配置